### PR TITLE
Add ros_environment build dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ else ()
     set(libpcap_FOUND TRUE)
 endif ()
 
+find_package(ros_environment REQUIRED)
+
 find_package(ament_cmake QUIET)
 find_package(catkin QUIET)
 

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,8 @@
   <author>Thomas Emter</author>
 
   <!-- Dependencies-->
+  <build_depend>ros_environment</build_depend>
+
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
   <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
Added ros_environment as a build dependency to make sure ROS_VERSION is set during CMake phase of build (needed by the rosidl generator to check member_of_group tag which is conditioned on this variable).

This is normally not a problem because most people build with a sourced environment and ros_environment is almost everywhere, but unfortunately not 100% everywhere.

This probably doesn't fix anything, but it makes the dependency on ros_environment explicit.