### PR TITLE
Added support for GLGSV messages

### DIFF
--- a/include/septentrio_gnss_driver/communication/async_manager.hpp
+++ b/include/septentrio_gnss_driver/communication/async_manager.hpp
@@ -398,6 +398,7 @@ namespace io {
                                     (currByte == NMEA_SYNC_BYTE_3a) ||
                                     (currByte == NMEA_SYNC_BYTE_3b) ||
                                     (currByte == NMEA_SYNC_BYTE_3c) ||
+                                    (currByte == NMEA_SYNC_BYTE_3d) ||
                                     (currByte == NMEA_INS_SYNC_BYTE_3) ||
                                     (currByte == RESPONSE_SYNC_BYTE_3) ||
                                     (currByte == RESPONSE_SYNC_BYTE_3a))

--- a/include/septentrio_gnss_driver/communication/message_handler.hpp
+++ b/include/septentrio_gnss_driver/communication/message_handler.hpp
@@ -214,7 +214,7 @@ namespace io {
             {"$GBGGA", 0}, {"$GPRMC", 1}, {"$INRMC", 1}, {"$GNRMC", 1},
             {"$GARMC", 1}, {"$GBRMC", 1}, {"$GPGSA", 2}, {"$INGSA", 2},
             {"$GNGSA", 2}, {"$GAGSA", 2}, {"$GBGSA", 2}, {"$GPGSV", 3},
-            {"$INGSV", 3}, {"$GNGSV", 3}, {"$GAGSV", 3}, {"$GBGSV", 3}};
+            {"$INGSV", 3}, {"$GNGSV", 3}, {"$GAGSV", 3}, {"$GBGSV", 3}, {"$GLGSV", 3}};
 
         /**
          * @brief Since NavSatFix etc. need PVTGeodetic, incoming PVTGeodetic blocks

--- a/include/septentrio_gnss_driver/communication/telegram.hpp
+++ b/include/septentrio_gnss_driver/communication/telegram.hpp
@@ -59,6 +59,8 @@ static const uint8_t NMEA_SYNC_BYTE_3a = 0x4E;
 static const uint8_t NMEA_SYNC_BYTE_3b = 0x41;
 //! 0x42 is ASCII for B - 3rd byte to indicate NMEA-type ASCII message
 static const uint8_t NMEA_SYNC_BYTE_3c = 0x42;
+//! 0x4C is ASCII for L - 3rd byte to indicate NMEA-type ASCII message
+static const uint8_t NMEA_SYNC_BYTE_3d = 0x4C;
 //! 0x49 is ASCII for I - 2nd byte to indicate INS NMEA-type ASCII message
 static const uint8_t NMEA_INS_SYNC_BYTE_2 = 0x49;
 //! 0x4E is ASCII for N - 3rd byte to indicate INS NMEA-type ASCII message

--- a/src/septentrio_gnss_driver/communication/message_handler.cpp
+++ b/src/septentrio_gnss_driver/communication/message_handler.cpp
@@ -2938,6 +2938,7 @@ namespace io {
                 publish<GpgsaMsg>("gpgsa", msg);
                 break;
             }
+            case 3:
             case 4:
             {
                 // Create NmeaSentence struct to pass to GpgsvParser::parseASCII


### PR DESCRIPTION
I don't know why, these messages started appearing on our receivers out of nothing and the driver doesn't know them and spits out errors. Maybe GLONASS updated firmware up there?

This PR adds support for parsing these messages.

I'm not particularly sure about the change in message_handler.cpp . It seems to me it could have not worked at all for GSV NMEA messages, but that's weird. I think the `case 4` is no longer needed, but to be sure, I rather left it there.

Tested on Mosaic-H eval kit.