### PR TITLE
Fix Aux1 antenna type in INS multi-antenna mode

### DIFF
--- a/src/septentrio_gnss_driver/communication/communication_core.cpp
+++ b/src/septentrio_gnss_driver/communication/communication_core.cpp
@@ -418,7 +418,8 @@ namespace io {
                 if (settings_->multi_antenna)
                 {
                     std::stringstream ss;
-                    ss << "sat, Aux1, \"" << settings_->ant_type << "\"" << "\x0D";
+                    // FIX: was settings_->ant_type — Aux1 must use its own ant_aux1_type
+                    ss << "sat, Aux1, \"" << settings_->ant_aux1_type << "\"" << "\x0D";
                     send(ss.str());
                 }
             } else if (settings_->septentrio_receiver_type == "gnss")


### PR DESCRIPTION
When configuring an INS receiver in dual-antenna mode (`receiver_type: ins`, `multi_antenna: true`) and setting a real `ant_aux1_type`  e.g. a different antenna model on Aux1 than on Main  the driver builds the Aux1 `sat` command from `settings_->ant_type` instead of `settings_->ant_aux1_type`:

```cpp
ss << "sat, Aux1, \"" << settings_->ant_type << "\"" << "\x0D";
```

The receiver then loads the Main antenna's phase-center model for Aux1, so the auxiliary antenna's carrier-phase measurements are corrected with the wrong phase-center variation (or none, when the configured type doesn't match the hardware). The GNSS branch already handles this correctly, using `ant_aux1_type` in its `sao, Aux1, …` command. The issue is masked while both parameters stay at the default `"Unknown"` and surfaces once real antenna types are configured.

With the correct type, the Aux1 phase-center offset and variation are properly modeled, so the dual-antenna baseline is resolved from correctly corrected carrier phase  improving attitude (heading/pitch) accuracy and consistency, which matters most when Main and Aux1 are different antenna models.

Fix: use `settings_->ant_aux1_type` for the Aux1 `sat` command, matching the GNSS branch.