### PR TITLE
fix: populate GPRMC/GPGGA utc_seconds regardless of use_gnss_time

### DIFF
--- a/src/septentrio_gnss_driver/parsers/nmea_parsers/gpgga.cpp
+++ b/src/septentrio_gnss_driver/parsers/nmea_parsers/gpgga.cpp
@@ -72,35 +72,33 @@ GpggaMsg GpggaParser::parseASCII(const NMEASentence& sentence,
 
     msg.message_id = sentence.get_body()[0];
 
+    double utc_double = 0.0;
+    bool utc_ok = string_utilities::toDouble(sentence.get_body()[1], utc_double);
+    if (utc_ok)
+    {
+        msg.utc_seconds = parsing_utilities::convertUTCDoubleToSeconds(utc_double);
+    }
+
     if (!use_gnss_time || sentence.get_body()[1].empty() ||
         sentence.get_body()[1] == "0")
     {
         msg.header.stamp = timestampToRos(time_obj);
+    } else if (!utc_ok)
+    {
+        throw ParseException(
+            "Error parsing UTC seconds in GPGGA"); // E.g. if one of the
+                                                   // fields of the NMEA UTC
+                                                   // string is empty
     } else
     {
-        double utc_double;
-        if (string_utilities::toDouble(sentence.get_body()[1], utc_double))
-        {
-            // ROS_DEBUG("utc_double is %f", (float) utc_double);
-            msg.utc_seconds =
-                parsing_utilities::convertUTCDoubleToSeconds(utc_double);
-
-            // The Header's Unix Epoch time stamp
-            time_t unix_time_seconds =
-                parsing_utilities::convertUTCtoUnix(utc_double);
-            // The following assumes that there are two digits after the
-            // decimal point in utc_double, i.e. in the NMEA UTC time.
-            Timestamp unix_time_nanoseconds =
-                unix_time_seconds * 1000000000 +
-                (static_cast<Timestamp>(utc_double * 100) % 100) * 10000;
-            msg.header.stamp = timestampToRos(unix_time_nanoseconds);
-        } else
-        {
-            throw ParseException(
-                "Error parsing UTC seconds in GPGGA"); // E.g. if one of the
-                                                       // fields of the NMEA UTC
-                                                       // string is empty
-        }
+        // The Header's Unix Epoch time stamp
+        time_t unix_time_seconds = parsing_utilities::convertUTCtoUnix(utc_double);
+        // The following assumes that there are two digits after the
+        // decimal point in utc_double, i.e. in the NMEA UTC time.
+        Timestamp unix_time_nanoseconds =
+            unix_time_seconds * 1000000000 +
+            (static_cast<Timestamp>(utc_double * 100) % 100) * 10000;
+        msg.header.stamp = timestampToRos(unix_time_nanoseconds);
     }
 
     bool valid = true;

--- a/src/septentrio_gnss_driver/parsers/nmea_parsers/gprmc.cpp
+++ b/src/septentrio_gnss_driver/parsers/nmea_parsers/gprmc.cpp
@@ -77,34 +77,33 @@ GprmcMsg GprmcParser::parseASCII(const NMEASentence& sentence,
 
     msg.message_id = sentence.get_body()[0];
 
+    double utc_double = 0.0;
+    bool utc_ok = string_utilities::toDouble(sentence.get_body()[1], utc_double);
+    if (utc_ok)
+    {
+        msg.utc_seconds = parsing_utilities::convertUTCDoubleToSeconds(utc_double);
+    }
+
     if (!use_gnss_time || sentence.get_body()[1].empty() ||
         sentence.get_body()[1] == "0")
     {
         msg.header.stamp = timestampToRos(time_obj);
+    } else if (!utc_ok)
+    {
+        throw ParseException(
+            "Error parsing UTC seconds in GPRMC"); // E.g. if one of the
+                                                   // fields of the NMEA UTC
+                                                   // string is empty
     } else
     {
-        double utc_double;
-        if (string_utilities::toDouble(sentence.get_body()[1], utc_double))
-        {
-            msg.utc_seconds =
-                parsing_utilities::convertUTCDoubleToSeconds(utc_double);
-
-            // The Header's Unix Epoch time stamp
-            time_t unix_time_seconds =
-                parsing_utilities::convertUTCtoUnix(utc_double);
-            // The following assumes that there are two digits after the
-            // decimal point in utc_double, i.e. in the NMEA UTC time.
-            Timestamp unix_time_nanoseconds =
-                unix_time_seconds * 1000000000 +
-                (static_cast<Timestamp>(utc_double * 100) % 100) * 10000;
-            msg.header.stamp = timestampToRos(unix_time_nanoseconds);
-        } else
-        {
-            throw ParseException(
-                "Error parsing UTC seconds in GPRMC"); // E.g. if one of the
-                                                       // fields of the NMEA UTC
-                                                       // string is empty
-        }
+        // The Header's Unix Epoch time stamp
+        time_t unix_time_seconds = parsing_utilities::convertUTCtoUnix(utc_double);
+        // The following assumes that there are two digits after the
+        // decimal point in utc_double, i.e. in the NMEA UTC time.
+        Timestamp unix_time_nanoseconds =
+            unix_time_seconds * 1000000000 +
+            (static_cast<Timestamp>(utc_double * 100) % 100) * 10000;
+        msg.header.stamp = timestampToRos(unix_time_nanoseconds);
     }
 
     bool valid = true;


### PR DESCRIPTION
## Summary

**Fixes #183**:  `utc_seconds` was always 0.0 in Gprmc/Gpgga when `use_gnss_time: false` (the default), since it was only parsed inside the `use_gnss_time` conditional. See the issue for details.

Moved the UTC-field parsing out of that conditional in both gprmc.cpp and gpgga.cpp, so `utc_seconds` is now populated whenever the field is present/parsable, independently of `use_gnss_time`. No change to header.stamp or any other field/behavior.

`use_gnss_time` should only decide the clock source for header.stamp, not whether the sentence's own fields get parsed. `utc_seconds` now follows the same rule already applied to `date`.

## Test plan
- [x] Confirmed header.stamp/exception behavior unchanged (same conditions as before).
- [x] Tested live on a Septentrio mosaic-H receiver with `use_gnss_time: false`: `utc_seconds` is now correctly populated on both /gprmc and /gpgga.